### PR TITLE
Enabling by default

### DIFF
--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -5,7 +5,7 @@ import type { Props } from '@astrojs/starlight/props'
 
 <starlight-overrides-map>
   <div class="starlight-overrides-map-toolbar">
-    <label><input name="enabled" type="checkbox" />Enabled</label>
+    <label><input name="enabled" type="checkbox" checked />Enabled</label>
     <label><input name="open" type="checkbox" checked />Open documentation on click</label>
     <label><input name="copy" type="checkbox" />Copy override name on click</label>
   </div>


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

This is an unsolicited PR to suggest that the site be enabled by default!
**Why**

I am always initially confused until I remember I need to enable the hover effect. The only reason I visit this site is for its functionality, so it seems like enabled by default would help people unfamiliar with the site understand immediately how to use it.

**How**

I copied the `checked` attribute from the adjacent field that is checked by default.

**Screenshots**

Feel free to close if there's a good reason not to do this, but it fools me every time, and I **know** how to use this site. 

<!-- Feel free to add additional comments. -->
