### PR TITLE
Change default behavior

### DIFF
--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -5,8 +5,8 @@ import type { Props } from '@astrojs/starlight/props'
 
 <starlight-overrides-map>
   <div class="starlight-overrides-map-toolbar">
-    <label><input name="enabled" type="checkbox" />Enabled</label>
-    <label><input name="open" type="checkbox" checked />Open documentation on click</label>
+    <label><input name="enabled" type="checkbox" checked />Enabled</label>
+    <label><input name="open" type="checkbox" />Open documentation on click</label>
     <label><input name="copy" type="checkbox" />Copy override name on click</label>
   </div>
 </starlight-overrides-map>
@@ -135,7 +135,7 @@ import type { Props } from '@astrojs/starlight/props'
   customElements.define(
     'starlight-overrides-map',
     class StarlightOverridesMap extends HTMLElement {
-      #options: Options = { enabled: false, openDocumentationOnClick: true, copyNameOnClick: false }
+      #options: Options = { enabled: true, openDocumentationOnClick: false, copyNameOnClick: false }
       #currentOverride: Override | undefined
       #highlight: HTMLDivElement | undefined
       #tooltip: HTMLDivElement | undefined


### PR DESCRIPTION
Based on discussions, this PR updates the default behavior to be enabled by default without a redirect to the documentation.