### PR TITLE
Add a small instructions overlay

### DIFF
--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -74,12 +74,15 @@ import type { Props } from '@astrojs/starlight/props'
     z-index: 90;
     inset-block-end: 1rem;
     inset-inline-end: 1rem;
-    width: 30rem;
     max-width: 75vw;
     padding: 1rem 1.5rem;
     background-color: var(--starlight-overrides-map-toolbar-bg-color);
     color: white;
     box-shadow: var(--sl-shadow-lg);
+    border-radius: 0.5rem;
+  }
+  .starlight-overrides-map-instructions[open] {
+    width: 30rem;
   }
 
   .starlight-overrides-map-toolbar {

--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -4,6 +4,16 @@ import type { Props } from '@astrojs/starlight/props'
 ---
 
 <starlight-overrides-map>
+  <details open class="starlight-overrides-map-instructions">
+    <summary><strong>How to use</strong></summary>
+    <p>This interactive map helps you find the right component to override in Starlight.</p>
+    <ol>
+      <li>Hover over elements on the page to see which Starlight component they are part of.</li>
+      <li>
+        In the toolbar, choose whether clicking a component should take you to the Starlight docs or copy its name.
+      </li>
+    </ol>
+  </details>
   <div class="starlight-overrides-map-toolbar">
     <label><input name="enabled" type="checkbox" checked />Enabled</label>
     <label><input name="open" type="checkbox" />Open documentation on click</label>
@@ -59,6 +69,19 @@ import type { Props } from '@astrojs/starlight/props'
 </style>
 
 <style>
+  .starlight-overrides-map-instructions {
+    position: fixed;
+    z-index: 90;
+    inset-block-end: 1rem;
+    inset-inline-end: 1rem;
+    width: 30rem;
+    max-width: 75vw;
+    padding: 1rem 1.5rem;
+    background-color: var(--starlight-overrides-map-toolbar-bg-color);
+    color: white;
+    box-shadow: var(--sl-shadow-lg);
+  }
+
   .starlight-overrides-map-toolbar {
     align-items: center;
     background-color: var(--starlight-overrides-map-toolbar-bg-color);


### PR DESCRIPTION
**Describe the pull request**

This PR adds a small overlay with instructions about how to use the overrides map.

**Why**

This change helps first-time users of the map learn what to do next when first landing on the site.

**How**

I added a `<details>` element to the `PageFrame` override with simple instructions. This is first in the DOM order before the toolbar to provide instructions first. The element is then positioned in the bottom right corner. It can be collapsed to take up less space in case it is obscuring something a user wants to hover.

**Screenshots**

![Starlight Overrides map with “How to use” overlay in the bottom right corner](https://github.com/user-attachments/assets/727f10e1-7937-4205-99cf-f63e2c758725)

![Starlight Overrides map with “How to use” overlay collapsed to a small button in the bottom right corner](https://github.com/user-attachments/assets/ec7d5645-ae83-4666-87f7-3b7df8c61076)
